### PR TITLE
Set current VSCode GoLang settings as default settings for development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,180 @@
+{
+  // Tags and options configured here will be used by the Add Tags command to add tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, json tags are added.
+  "go.addTags": {
+    "tags": "json",
+    "options": "json=omitempty",
+    "promptForTags": false,
+    "transform": "snakecase"
+  },
+
+  // Alternate tools or alternate paths for the same tools used by the Go extension. Provide either absolute path or the name of the binary in GOPATH/bin, GOROOT/bin or PATH. Useful when you want to use wrapper script for the Go tools or versioned tools from https://gopkg.in.
+  "go.alternateTools": {},
+
+  // Include unimported packages in auto-complete suggestions.
+  "go.autocompleteUnimportedPackages": false,
+
+  // Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ['-ldflags="-s"'])
+  "go.buildFlags": [],
+
+  // Compiles code on file save using 'go build -i' or 'go test -c -i'. Options are 'workspace', 'package or 'off'.
+  "go.buildOnSave": "package",
+
+  // The Go build tags to use for all commands that support a `-tags '...'` argument
+  "go.buildTags": "",
+
+  // This option lets you choose the way to display code coverage. Choose either to highlight the complete line or to show a decorator in the gutter. You can customize the color for the former and the style for the latter.
+  "go.coverageDecorator": {
+    "type": "highlight",
+    "coveredHighlightColor": "rgba(64,128,128,0.5)",
+    "uncoveredHighlightColor": "rgba(128,64,64,0.25)",
+    "coveredGutterStyle": "blockblue",
+    "uncoveredGutterStyle": "slashyellow"
+  },
+
+  // Use these options to control whether only covered or only uncovered code or both should be highlighted after running test coverage
+  "go.coverageOptions": "showBothCoveredAndUncoveredCode",
+
+  // If true, runs 'go test -coverprofile' on save and shows test coverage.
+  "go.coverOnSave": false,
+
+  // If true, shows test coverage when Go: Test Function at cursor command is run.
+  "go.coverOnSingleTest": false,
+
+  // If true, shows test coverage when Go: Test Package command is run.
+  "go.coverOnTestPackage": true,
+
+  //
+  "go.delveConfig": {},
+
+  // Pick 'godoc' or 'gogetdoc' to get documentation. In Go 1.5, godoc is used regardless of the choice here.
+  "go.docsTool": "godoc",
+
+  // Experimental Feature: Enable/Disable entries from the context menu in the editor.
+  "go.editorContextMenuCommands": {
+    "toggleTestFile": true,
+    "addTags": true,
+    "removeTags": false,
+    "testAtCursor": true,
+    "testFile": false,
+    "testPackage": false,
+    "generateTestForFunction": true,
+    "generateTestForFile": false,
+    "generateTestForPackage": false,
+    "addImport": true,
+    "testCoverage": true,
+    "playground": true
+  },
+
+  // Feature level setting to enable/disable code lens for references and run/debug tests
+  "go.enableCodeLens": {
+    "references": false,
+    "runtest": true
+  },
+
+  // Flags to pass to format tool (e.g. ['-s'])
+  "go.formatFlags": [],
+
+  // Pick 'gofmt', 'goimports', 'goreturns' or 'goformat' to run on format.
+  "go.formatTool": "goreturns",
+
+  // Enable gocode's autobuild feature
+  "go.gocodeAutoBuild": false,
+
+  // If go, use standard Go package lookup rules for completions. If gb, use gb-specific lookup rules for completions
+  "go.gocodePackageLookupMode": "go",
+
+  // Specify GOPATH here to override the one that is set as environment variable. The inferred GOPATH from workspace root overrides this, if go.inferGopath is set to true.
+  "go.gopath": null,
+
+  // Specifies the GOROOT to use when no environment variable is set.
+  "go.goroot": null,
+
+  // Folder names (not paths) to ignore while using Go to Symbol in Workspace feature
+  "go.gotoSymbol.ignoreFolders": [],
+
+  // If false, the standard library located at $GOROOT will be excluded while using the Go to Symbol in File feature
+  "go.gotoSymbol.includeGoroot": false,
+
+  // If false, the import statements will be excluded while using the Go to Symbol in File feature
+  "go.gotoSymbol.includeImports": false,
+
+  // Infer GOPATH from the workspace root.
+  "go.inferGopath": false,
+
+  // If true, then `-i` flag will be passed to `go build` everytime the code is compiled.
+  "go.installDependenciesWhenBuilding": true,
+
+  // Use this setting to enable/disable experimental features from the language server.
+  "go.languageServerExperimentalFeatures": {
+    "format": false,
+    "autoComplete": false
+  },
+
+  // Flags like -trace and -logfile to be used while running the language server.
+  "go.languageServerFlags": [],
+
+  // Flags to pass to Lint tool (e.g. ["-min_confidence=.8"])
+  "go.lintFlags": [],
+
+  // Lints code on file save using the configured Lint tool. Options are 'workspace', 'package' or 'off'.
+  "go.lintOnSave": "package",
+
+  // Specifies Lint tool name.
+  "go.lintTool": "golint",
+
+  // Use gotype on the file currently being edited and report any semantic or syntactic errors found after configured delay.
+  "go.liveErrors": {
+    "enabled": false,
+    "delay": 500
+  },
+
+  //
+  "go.playground": {
+    "openbrowser": true,
+    "share": true,
+    "run": true
+  },
+
+  // Tags and options configured here will be used by the Remove Tags command to remove tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, all tags and options will be removed.
+  "go.removeTags": {
+    "tags": "",
+    "options": "",
+    "promptForTags": false
+  },
+
+  // Absolute path to a file containing environment variables definitions. File contents should be of the form key=value.
+  "go.testEnvFile": null,
+
+  // Environment variables that will passed to the process that runs the Go tests
+  "go.testEnvVars": {},
+
+  // Flags to pass to `go test`. If null, then buildFlags will be used.
+  "go.testFlags": null,
+
+  // Run 'go test' on save for current package. It is not advised to set this to `true` when you have Auto Save enabled.
+  "go.testOnSave": false,
+
+  // Specifies the timeout for go test in ParseDuration format.
+  "go.testTimeout": "30s",
+
+  // Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)
+  "go.toolsEnvVars": {},
+
+  // Location to install the Go tools that the extension depends on if you don't want them in your GOPATH.
+  "go.toolsGopath": "",
+
+  // Complete functions with their parameter signature, including the variable types
+  "go.useCodeSnippetsOnFunctionSuggest": false,
+
+  // Complete functions with their parameter signature, excluding the variable types
+  "go.useCodeSnippetsOnFunctionSuggestWithoutType": false,
+
+  // Experimental: Not available in Windows. Use Go language server from Sourcegraph for Hover, Definition, Find All References, Signature Help, File Outline and Workspace Symbol features instead of tools like guru, godef, go-outline and go-symbol
+  "go.useLanguageServer": false,
+
+  // Flags to pass to `go tool vet` (e.g. ['-all', '-shadow'])
+  "go.vetFlags": [],
+
+  // Vets code on file save using 'go tool vet'. Options are 'workspace', 'package or 'off'.
+  "go.vetOnSave": "package"
+}


### PR DESCRIPTION
These settings are default for VSCode for GoLang development. Setting them as standards if in future they change. Will soon write an `editorconfig` and `GoSublime` build for the same settings.