### PR TITLE
Add container config template for static pages

### DIFF
--- a/configs/containerLevel/template.static.sdslabs.co.conf
+++ b/configs/containerLevel/template.static.sdslabs.co.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    server_name  template.static.sdslabs.co;
+
+    access_log  /var/log/nginx/template.access.log  main;
+    error_log /var/log/nginx/template.error.log warn;
+
+    location / {
+        root   /SDS/template/;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
In this file, if the user creates a project called `myAwesomeSite`, the word `template` will be replaced by `myAwesomeSite`