### PR TITLE
fix(jwt): refresh route should not validate expiration of old token.

### DIFF
--- a/services/kaze/middlewares/jwt.go
+++ b/services/kaze/middlewares/jwt.go
@@ -70,7 +70,7 @@ var JWT = &jwt.GinJWTMiddleware{
 	Realm:           "Gasper",
 	Key:             []byte(configs.GasperConfig.Secret),
 	Timeout:         time.Hour,
-	MaxRefresh:      time.Hour,
+	MaxRefresh:      28 * 24 * time.Hour,
 	TokenLookup:     "header: Authorization",
 	TokenHeadName:   "Bearer",
 	TimeFunc:        time.Now,

--- a/services/kaze/routes.go
+++ b/services/kaze/routes.go
@@ -33,7 +33,7 @@ func NewService() http.Handler {
 	{
 		auth.POST("/login", m.JWT.LoginHandler)
 		auth.POST("/register", m.ValidateRegistration, c.Register)
-		auth.GET("/refresh", m.JWT.MiddlewareFunc(), m.JWT.RefreshHandler)
+		auth.GET("/refresh", m.JWT.RefreshHandler)
 	}
 
 	app := router.Group("/apps")


### PR DESCRIPTION
Refresh route is used to keep a user logged in for "x" amount of time.
If the user is logged out, a simple request to refresh route with
expired token should return a new token.

Here the max refresh time is set to 1 month since we'd want a user to be
logged in for atleast a month without logging in from the start.

A client will be expected to send a request to refresh route after 1
hour that is the expiration of the old token. It can simply be done by
storing when the last token was received and comparing the time when the
new request is being sent. No need to automate or clutter the client as
well as un-necessary requests to the server for token refreshes.

Signed-off-by: Vaibhav <vrongmeal@gmail.com>