### PR TITLE
Clone private repo within docker container

### DIFF
--- a/lib/api/application.go
+++ b/lib/api/application.go
@@ -100,7 +100,15 @@ func SetupApplication(app types.Application) types.ResponseError {
 		return types.NewResErr(500, "git init unsuccessful", err)
 	}
 
-	_, err = docker.ExecProcess(app.GetContainerID(), []string{"git", "remote", "add", "origin", app.GetGitRepositoryURL()})
+	var cloneURL string
+	if len(app.GetGitAccessToken()) > 0 {
+		split := strings.Split(app.GetGitRepositoryURL(), "//")
+		cloneURL = fmt.Sprintf("https://oauth2:%s@%s", app.GetGitAccessToken() , split[1])
+	} else {
+		cloneURL = app.GetGitRepositoryURL()
+	}
+
+	_, err = docker.ExecProcess(app.GetContainerID(), []string{"git", "remote", "add", "origin", cloneURL})
 	if err != nil {
 		return types.NewResErr(500, "setting remote unsuccessful", err)
 	}


### PR DESCRIPTION
Fixes #243 

For cloning private repositories, I've changed the clone URL from
`https://<github/gitlab>.com/<username>/<project name>.git` 
 in the format:
`https://oauth2:` + `Personal Access Token` + `@` + `<github/gitlab>.com/<username>/<project name>.git`

Works for both private GitHub and GitLab repositories