### PR TITLE
Fix unlinkat error in make tools and bind mount cleanup

### DIFF
--- a/lib/docker/container.go
+++ b/lib/docker/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"time"
+	"os"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -18,6 +19,21 @@ import (
 func CreateApplicationContainer(containerCfg types.ApplicationContainer) (string, error) {
 	ctx := context.Background()
 	volume := fmt.Sprintf("%s:%s", containerCfg.StoreDir, containerCfg.WorkDir)
+
+	// Create the host directory for bind mount with appropriate permissions
+    err := os.MkdirAll(containerCfg.StoreDir, 0755)
+    if err != nil {
+        return "", fmt.Errorf("failed to create directory: %w", err)
+    }
+	// Set proper permissions for the host directory
+	err = os.Chown(containerCfg.StoreDir, os.Getuid(), os.Getgid())
+	if err != nil { 
+		return "", fmt.Errorf("failed to set ownership: %w", err)
+	}
+	err = os.Chmod(containerCfg.StoreDir, 0755)
+	if err != nil { 
+		return "", fmt.Errorf("failed to set permissions: %w", err)
+	}
 
 	// convert map to list of strings
 	envArr := []string{}

--- a/lib/docker/delete.go
+++ b/lib/docker/delete.go
@@ -1,6 +1,8 @@
 package docker
 
 import (
+	"fmt"
+	"github.com/sdslabs/gasper/lib/utils"
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -8,8 +10,38 @@ import (
 // DeleteContainer deletes a docker container
 func DeleteContainer(containerID string) error {
 	ctx := context.Background()
-	err := StopContainer(containerID)
 
+	// Inspect the container to get its working directory
+	containerJSON, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		utils.LogError("Docker-DeleteContainer-1", err)
+		return err
+	}
+	workingDir := containerJSON.Config.WorkingDir
+	if workingDir != "" {
+		// Clear the working directory inside the container, including hidden files and directories
+		cmd := []string{"sh", "-c", fmt.Sprintf("rm -rf %s/* %s/.*", workingDir, workingDir)}
+		execConfig := types.ExecConfig{
+			Cmd:          cmd,
+			AttachStdout: true,
+			AttachStderr: true,
+			Privileged:   true,
+		}
+
+		execIDResp, err := cli.ContainerExecCreate(ctx, containerID, execConfig)
+		if err != nil {
+			utils.LogError("Docker-DeleteContainer-2", err)
+			return err
+		}
+
+		err = cli.ContainerExecStart(ctx, execIDResp.ID, types.ExecStartCheck{})
+		if err != nil {
+			utils.LogError("Docker-DeleteContainer-3", err)
+			return err
+		}
+	}
+
+	err = StopContainer(containerID)
 	if err != nil {
 		return err
 	}

--- a/scripts/build/install_fresh.sh
+++ b/scripts/build/install_fresh.sh
@@ -12,6 +12,7 @@ mkdir -p bin
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 cd $tmp_dir
 GOPATH=$tmp_dir go install github.com/pilu/fresh@latest
+chmod -R u+rw $tmp_dir
 cp $tmp_dir/bin/fresh $project_dir/bin/fresh
 rm -rf $tmp_dir
 

--- a/scripts/build/install_golint.sh
+++ b/scripts/build/install_golint.sh
@@ -12,6 +12,7 @@ mkdir -p bin
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 cd $tmp_dir
 GOPATH=$tmp_dir go install golang.org/x/lint/golint@latest
+chmod -R u+rw $tmp_dir
 cp $tmp_dir/bin/golint $project_dir/bin/golint
 rm -rf $tmp_dir
 

--- a/services/appmaker/helper.go
+++ b/services/appmaker/helper.go
@@ -34,13 +34,18 @@ func containerCleanup(appName string) error {
 
 // diskCleanup cleans the specified application's container and local storage
 func diskCleanup(appName string) {
+	err := containerCleanup(appName)
+	if err != nil {
+		utils.LogError("AppMaker-Helper-5", fmt.Errorf("container cleanup failed for %s: %w", appName, err))
+		return
+	}
+	
 	appDir := filepath.Join(path, fmt.Sprintf("storage/%s", appName))
-	storeCleanupChan := make(chan error)
-	go func() {
-		storeCleanupChan <- storageCleanup(appDir)
-	}()
-	containerCleanup(appName)
-	<-storeCleanupChan
+	err = storageCleanup(appDir)
+	if err != nil {
+		utils.LogError("AppMaker-Helper-6", fmt.Errorf("storage cleanup failed for %s: %w", appName, err))
+		return
+	}
 }
 
 // stateCleanup removes the application's data from MongoDB and Redis


### PR DESCRIPTION
### Summary
This pull request addresses the `unlinkat` error encountered while running `make tools` and during `bind mount` cleanup.

### Details
- **Issue**: Elevated privileges on bind mounts caused `unlinkat` errors during deletion.
- **Solution**:
  1. Create bind mounts explicitly to avoid elevated privileges.
  2. During container deletion, first remove all contents inside the working directory, then kill the container.
  3. In DiskCleanup, perform ContainerCleanup before StorageCleanup.

### Testing
- Verified that `make tools` runs successfully without errors.
- Ensured that bind mounts and directories are cleaned up correctly.