### PR TITLE
Fix: MongoDB and Redis Containers are now picked up automatically when gasper restarts

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -42,7 +42,18 @@ func buildHTTPServer(handler http.Handler, port int) *http.Server {
 }
 
 func setupDatabaseContainer(serviceName string) {
-	containers := appmaker.FetchAllApplicationNames()
+
+	var containers []string
+	var err error
+	if serviceName == types.MongoDBGasper || serviceName == types.RedisGasper {
+		containers, err = docker.ListContainers()
+		if err != nil {
+			utils.LogError("Main-Helper-5.5", fmt.Errorf("Error Fetching List of Running Containers: %v", err))
+			return
+		}
+	} else {
+		containers = appmaker.FetchAllApplicationNames()
+	}
 
 	if !utils.Contains(containers, serviceName) {
 		utils.LogInfo("Main-Helper-6", "No %s instance found in host. Building the instance.", strings.Title(serviceName))


### PR DESCRIPTION
Fixes #291

`appmaker.FetchAllApplicationNames()` depends on mongodb, but it is called during mongodb setup before the database is ready which makes it return an empty list.
Instead now it checks if `serviceName` is `mongodb_gasper` or `redis_gasper` and then selectively calls `docker.ListContainers()`. If its a dbmaker call then it will proceed normally through `appmaker.FetchAllApplicationNames()`