### PR TITLE
Implement Shift Node Route

### DIFF
--- a/lib/docker/container.go
+++ b/lib/docker/container.go
@@ -186,14 +186,14 @@ func ContainerRestart(containerID string) error {
 	return cli.ContainerRestart(ctx, containerID, nil)
 }
 
-func BulkContainerRestart(containerIDs []string) error {
-	for _, app := range containerIDs {
+func BulkContainerRestart(containerNames []string) {
+	for _, app := range containerNames {
 		err := ContainerRestart(app)
 		if err != nil {
-			return err
+			utils.LogInfo("Bulk Container Restart", fmt.Sprintf("container %s not found", app))
+			continue
 		}
 	}
-	return nil
 }
 
 // UpdateContainerResources updates the resources of the container corresponding to given containerID

--- a/lib/docker/container.go
+++ b/lib/docker/container.go
@@ -186,6 +186,16 @@ func ContainerRestart(containerID string) error {
 	return cli.ContainerRestart(ctx, containerID, nil)
 }
 
+func BulkContainerRestart(containerIDs []string) error {
+	for _, app := range containerIDs {
+		err := ContainerRestart(app)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // UpdateContainerResources updates the resources of the container corresponding to given containerID
 func UpdateContainerResources(containerID string, updateConfig container.UpdateConfig) error {
 	ctx := context.Background()

--- a/lib/docker/delete.go
+++ b/lib/docker/delete.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"github.com/docker/docker/api/types"
+	"github.com/sdslabs/gasper/lib/utils"
 	"golang.org/x/net/context"
 )
 
@@ -20,6 +21,21 @@ func DeleteContainer(containerID string) error {
 		return err
 	}
 
+	return nil
+}
+
+func BulkDeleteContainers(containerNames []string) error {
+	allContainers, err := ListContainers()
+	if err != nil {
+		return err
+	}
+	for _, containerID := range containerNames {
+		if utils.Contains(allContainers, containerID) {
+			if err := DeleteContainer(containerID); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/lib/factory/node_manager.go
+++ b/lib/factory/node_manager.go
@@ -83,7 +83,12 @@ func GracefulDown(instanceURL string, appsOnNode []types.ApplicationConfig) (boo
 		appNamesOnNode = append(appNamesOnNode, app.Name)
 	}
 
-	res, err := client.StopAppContainers(ctx, &pb.DownNodeRequestBody{
+	// res, err := client.StopAppContainers(ctx, &pb.DownNodeRequestBody{
+	// 	InstanceURL: instanceURL,
+	// 	Data:        appNamesOnNode,
+	// })
+
+	res, err := client.DeleteAppContainers(ctx, &pb.DownNodeRequestBody{
 		InstanceURL: instanceURL,
 		Data:        appNamesOnNode,
 	})

--- a/lib/factory/node_manager.go
+++ b/lib/factory/node_manager.go
@@ -27,8 +27,15 @@ func GracefulUp(instanceURL string, appsOnNode []types.ApplicationConfig) (bool,
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	res, err := client.StartStoppedAppContainers(ctx, &pb.ContainerRequestBody{
+	var appNamesOnNode []string
+
+	for _, app := range appsOnNode {
+		appNamesOnNode = append(appNamesOnNode, app.Name)
+	}
+
+	res, err := client.StartStoppedAppContainers(ctx, &pb.DownNodeRequestBody{
 		InstanceURL: instanceURL,
+		Data:        appNamesOnNode,
 	})
 	if err != nil {
 		return false, err
@@ -51,7 +58,6 @@ func GracefulUp(instanceURL string, appsOnNode []types.ApplicationConfig) (bool,
 			}
 		}
 	}
-
 	return true, nil
 }
 

--- a/lib/factory/protos/application.proto
+++ b/lib/factory/protos/application.proto
@@ -10,13 +10,13 @@ service ApplicationFactory {
     rpc Rebuild (NameHolder) returns (ResponseBody) {}
     rpc FetchLogs (LogRequest) returns (LogResponse) {}
     rpc Update (NameHolder) returns (ResponseBody) {}
-    rpc StartStoppedAppContainers (ContainerRequestBody) returns (ContainerResponseBody) {}
+    rpc StartStoppedAppContainers (DownNodeRequestBody) returns (ContainerResponseBody) {}
     rpc StopAppContainers (DownNodeRequestBody) returns (DeletionResponse) {}
 }
 
 
 message ContainerRequestBody {
-    string instanceURL = 1;
+    string instanceURL = 1;  
 }
 
 message DownNodeRequestBody {

--- a/lib/factory/protos/application.proto
+++ b/lib/factory/protos/application.proto
@@ -12,6 +12,7 @@ service ApplicationFactory {
     rpc Update (NameHolder) returns (ResponseBody) {}
     rpc StartStoppedAppContainers (DownNodeRequestBody) returns (ContainerResponseBody) {}
     rpc StopAppContainers (DownNodeRequestBody) returns (DeletionResponse) {}
+    rpc DeleteAppContainers (DownNodeRequestBody) returns (DeletionResponse) {}
 }
 
 

--- a/lib/factory/protos/application/application.pb.go
+++ b/lib/factory/protos/application/application.pb.go
@@ -486,14 +486,14 @@ const file_application_proto_rawDesc = "" +
 	"\x04tail\x18\x02 \x01(\tR\x04tail\";\n" +
 	"\vLogResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x12\n" +
-	"\x04data\x18\x02 \x03(\tR\x04data2\x9a\x04\n" +
+	"\x04data\x18\x02 \x03(\tR\x04data2\x99\x04\n" +
 	"\x12ApplicationFactory\x12?\n" +
 	"\x06Create\x12\x18.application.RequestBody\x1a\x19.application.ResponseBody\"\x00\x12B\n" +
 	"\x06Delete\x12\x17.application.NameHolder\x1a\x1d.application.DeletionResponse\"\x00\x12?\n" +
 	"\aRebuild\x12\x17.application.NameHolder\x1a\x19.application.ResponseBody\"\x00\x12@\n" +
 	"\tFetchLogs\x12\x17.application.LogRequest\x1a\x18.application.LogResponse\"\x00\x12>\n" +
-	"\x06Update\x12\x17.application.NameHolder\x1a\x19.application.ResponseBody\"\x00\x12d\n" +
-	"\x19StartStoppedAppContainers\x12!.application.ContainerRequestBody\x1a\".application.ContainerResponseBody\"\x00\x12V\n" +
+	"\x06Update\x12\x17.application.NameHolder\x1a\x19.application.ResponseBody\"\x00\x12c\n" +
+	"\x19StartStoppedAppContainers\x12 .application.DownNodeRequestBody\x1a\".application.ContainerResponseBody\"\x00\x12V\n" +
 	"\x11StopAppContainers\x12 .application.DownNodeRequestBody\x1a\x1d.application.DeletionResponse\"\x00B\x0fZ\r./applicationb\x06proto3"
 
 var (
@@ -526,7 +526,7 @@ var file_application_proto_depIdxs = []int32{
 	5, // 2: application.ApplicationFactory.Rebuild:input_type -> application.NameHolder
 	7, // 3: application.ApplicationFactory.FetchLogs:input_type -> application.LogRequest
 	5, // 4: application.ApplicationFactory.Update:input_type -> application.NameHolder
-	0, // 5: application.ApplicationFactory.StartStoppedAppContainers:input_type -> application.ContainerRequestBody
+	1, // 5: application.ApplicationFactory.StartStoppedAppContainers:input_type -> application.DownNodeRequestBody
 	1, // 6: application.ApplicationFactory.StopAppContainers:input_type -> application.DownNodeRequestBody
 	4, // 7: application.ApplicationFactory.Create:output_type -> application.ResponseBody
 	6, // 8: application.ApplicationFactory.Delete:output_type -> application.DeletionResponse

--- a/lib/factory/protos/application/application.pb.go
+++ b/lib/factory/protos/application/application.pb.go
@@ -486,7 +486,7 @@ const file_application_proto_rawDesc = "" +
 	"\x04tail\x18\x02 \x01(\tR\x04tail\";\n" +
 	"\vLogResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x12\n" +
-	"\x04data\x18\x02 \x03(\tR\x04data2\x99\x04\n" +
+	"\x04data\x18\x02 \x03(\tR\x04data2\xf3\x04\n" +
 	"\x12ApplicationFactory\x12?\n" +
 	"\x06Create\x12\x18.application.RequestBody\x1a\x19.application.ResponseBody\"\x00\x12B\n" +
 	"\x06Delete\x12\x17.application.NameHolder\x1a\x1d.application.DeletionResponse\"\x00\x12?\n" +
@@ -494,7 +494,8 @@ const file_application_proto_rawDesc = "" +
 	"\tFetchLogs\x12\x17.application.LogRequest\x1a\x18.application.LogResponse\"\x00\x12>\n" +
 	"\x06Update\x12\x17.application.NameHolder\x1a\x19.application.ResponseBody\"\x00\x12c\n" +
 	"\x19StartStoppedAppContainers\x12 .application.DownNodeRequestBody\x1a\".application.ContainerResponseBody\"\x00\x12V\n" +
-	"\x11StopAppContainers\x12 .application.DownNodeRequestBody\x1a\x1d.application.DeletionResponse\"\x00B\x0fZ\r./applicationb\x06proto3"
+	"\x11StopAppContainers\x12 .application.DownNodeRequestBody\x1a\x1d.application.DeletionResponse\"\x00\x12X\n" +
+	"\x13DeleteAppContainers\x12 .application.DownNodeRequestBody\x1a\x1d.application.DeletionResponse\"\x00B\x0fZ\r./applicationb\x06proto3"
 
 var (
 	file_application_proto_rawDescOnce sync.Once
@@ -528,15 +529,17 @@ var file_application_proto_depIdxs = []int32{
 	5, // 4: application.ApplicationFactory.Update:input_type -> application.NameHolder
 	1, // 5: application.ApplicationFactory.StartStoppedAppContainers:input_type -> application.DownNodeRequestBody
 	1, // 6: application.ApplicationFactory.StopAppContainers:input_type -> application.DownNodeRequestBody
-	4, // 7: application.ApplicationFactory.Create:output_type -> application.ResponseBody
-	6, // 8: application.ApplicationFactory.Delete:output_type -> application.DeletionResponse
-	4, // 9: application.ApplicationFactory.Rebuild:output_type -> application.ResponseBody
-	8, // 10: application.ApplicationFactory.FetchLogs:output_type -> application.LogResponse
-	4, // 11: application.ApplicationFactory.Update:output_type -> application.ResponseBody
-	2, // 12: application.ApplicationFactory.StartStoppedAppContainers:output_type -> application.ContainerResponseBody
-	6, // 13: application.ApplicationFactory.StopAppContainers:output_type -> application.DeletionResponse
-	7, // [7:14] is the sub-list for method output_type
-	0, // [0:7] is the sub-list for method input_type
+	1, // 7: application.ApplicationFactory.DeleteAppContainers:input_type -> application.DownNodeRequestBody
+	4, // 8: application.ApplicationFactory.Create:output_type -> application.ResponseBody
+	6, // 9: application.ApplicationFactory.Delete:output_type -> application.DeletionResponse
+	4, // 10: application.ApplicationFactory.Rebuild:output_type -> application.ResponseBody
+	8, // 11: application.ApplicationFactory.FetchLogs:output_type -> application.LogResponse
+	4, // 12: application.ApplicationFactory.Update:output_type -> application.ResponseBody
+	2, // 13: application.ApplicationFactory.StartStoppedAppContainers:output_type -> application.ContainerResponseBody
+	6, // 14: application.ApplicationFactory.StopAppContainers:output_type -> application.DeletionResponse
+	6, // 15: application.ApplicationFactory.DeleteAppContainers:output_type -> application.DeletionResponse
+	8, // [8:16] is the sub-list for method output_type
+	0, // [0:8] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name

--- a/lib/factory/protos/application/application_grpc.pb.go
+++ b/lib/factory/protos/application/application_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	ApplicationFactory_Update_FullMethodName                    = "/application.ApplicationFactory/Update"
 	ApplicationFactory_StartStoppedAppContainers_FullMethodName = "/application.ApplicationFactory/StartStoppedAppContainers"
 	ApplicationFactory_StopAppContainers_FullMethodName         = "/application.ApplicationFactory/StopAppContainers"
+	ApplicationFactory_DeleteAppContainers_FullMethodName       = "/application.ApplicationFactory/DeleteAppContainers"
 )
 
 // ApplicationFactoryClient is the client API for ApplicationFactory service.
@@ -39,6 +40,7 @@ type ApplicationFactoryClient interface {
 	Update(ctx context.Context, in *NameHolder, opts ...grpc.CallOption) (*ResponseBody, error)
 	StartStoppedAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*ContainerResponseBody, error)
 	StopAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*DeletionResponse, error)
+	DeleteAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*DeletionResponse, error)
 }
 
 type applicationFactoryClient struct {
@@ -119,6 +121,16 @@ func (c *applicationFactoryClient) StopAppContainers(ctx context.Context, in *Do
 	return out, nil
 }
 
+func (c *applicationFactoryClient) DeleteAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*DeletionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeletionResponse)
+	err := c.cc.Invoke(ctx, ApplicationFactory_DeleteAppContainers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ApplicationFactoryServer is the server API for ApplicationFactory service.
 // All implementations must embed UnimplementedApplicationFactoryServer
 // for forward compatibility.
@@ -130,6 +142,7 @@ type ApplicationFactoryServer interface {
 	Update(context.Context, *NameHolder) (*ResponseBody, error)
 	StartStoppedAppContainers(context.Context, *DownNodeRequestBody) (*ContainerResponseBody, error)
 	StopAppContainers(context.Context, *DownNodeRequestBody) (*DeletionResponse, error)
+	DeleteAppContainers(context.Context, *DownNodeRequestBody) (*DeletionResponse, error)
 	mustEmbedUnimplementedApplicationFactoryServer()
 }
 
@@ -160,6 +173,9 @@ func (UnimplementedApplicationFactoryServer) StartStoppedAppContainers(context.C
 }
 func (UnimplementedApplicationFactoryServer) StopAppContainers(context.Context, *DownNodeRequestBody) (*DeletionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StopAppContainers not implemented")
+}
+func (UnimplementedApplicationFactoryServer) DeleteAppContainers(context.Context, *DownNodeRequestBody) (*DeletionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteAppContainers not implemented")
 }
 func (UnimplementedApplicationFactoryServer) mustEmbedUnimplementedApplicationFactoryServer() {}
 func (UnimplementedApplicationFactoryServer) testEmbeddedByValue()                            {}
@@ -308,6 +324,24 @@ func _ApplicationFactory_StopAppContainers_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ApplicationFactory_DeleteAppContainers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DownNodeRequestBody)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ApplicationFactoryServer).DeleteAppContainers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ApplicationFactory_DeleteAppContainers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ApplicationFactoryServer).DeleteAppContainers(ctx, req.(*DownNodeRequestBody))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ApplicationFactory_ServiceDesc is the grpc.ServiceDesc for ApplicationFactory service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -342,6 +376,10 @@ var ApplicationFactory_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "StopAppContainers",
 			Handler:    _ApplicationFactory_StopAppContainers_Handler,
+		},
+		{
+			MethodName: "DeleteAppContainers",
+			Handler:    _ApplicationFactory_DeleteAppContainers_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lib/factory/protos/application/application_grpc.pb.go
+++ b/lib/factory/protos/application/application_grpc.pb.go
@@ -37,7 +37,7 @@ type ApplicationFactoryClient interface {
 	Rebuild(ctx context.Context, in *NameHolder, opts ...grpc.CallOption) (*ResponseBody, error)
 	FetchLogs(ctx context.Context, in *LogRequest, opts ...grpc.CallOption) (*LogResponse, error)
 	Update(ctx context.Context, in *NameHolder, opts ...grpc.CallOption) (*ResponseBody, error)
-	StartStoppedAppContainers(ctx context.Context, in *ContainerRequestBody, opts ...grpc.CallOption) (*ContainerResponseBody, error)
+	StartStoppedAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*ContainerResponseBody, error)
 	StopAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*DeletionResponse, error)
 }
 
@@ -99,7 +99,7 @@ func (c *applicationFactoryClient) Update(ctx context.Context, in *NameHolder, o
 	return out, nil
 }
 
-func (c *applicationFactoryClient) StartStoppedAppContainers(ctx context.Context, in *ContainerRequestBody, opts ...grpc.CallOption) (*ContainerResponseBody, error) {
+func (c *applicationFactoryClient) StartStoppedAppContainers(ctx context.Context, in *DownNodeRequestBody, opts ...grpc.CallOption) (*ContainerResponseBody, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ContainerResponseBody)
 	err := c.cc.Invoke(ctx, ApplicationFactory_StartStoppedAppContainers_FullMethodName, in, out, cOpts...)
@@ -128,7 +128,7 @@ type ApplicationFactoryServer interface {
 	Rebuild(context.Context, *NameHolder) (*ResponseBody, error)
 	FetchLogs(context.Context, *LogRequest) (*LogResponse, error)
 	Update(context.Context, *NameHolder) (*ResponseBody, error)
-	StartStoppedAppContainers(context.Context, *ContainerRequestBody) (*ContainerResponseBody, error)
+	StartStoppedAppContainers(context.Context, *DownNodeRequestBody) (*ContainerResponseBody, error)
 	StopAppContainers(context.Context, *DownNodeRequestBody) (*DeletionResponse, error)
 	mustEmbedUnimplementedApplicationFactoryServer()
 }
@@ -155,7 +155,7 @@ func (UnimplementedApplicationFactoryServer) FetchLogs(context.Context, *LogRequ
 func (UnimplementedApplicationFactoryServer) Update(context.Context, *NameHolder) (*ResponseBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
 }
-func (UnimplementedApplicationFactoryServer) StartStoppedAppContainers(context.Context, *ContainerRequestBody) (*ContainerResponseBody, error) {
+func (UnimplementedApplicationFactoryServer) StartStoppedAppContainers(context.Context, *DownNodeRequestBody) (*ContainerResponseBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StartStoppedAppContainers not implemented")
 }
 func (UnimplementedApplicationFactoryServer) StopAppContainers(context.Context, *DownNodeRequestBody) (*DeletionResponse, error) {
@@ -273,7 +273,7 @@ func _ApplicationFactory_Update_Handler(srv interface{}, ctx context.Context, de
 }
 
 func _ApplicationFactory_StartStoppedAppContainers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ContainerRequestBody)
+	in := new(DownNodeRequestBody)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func _ApplicationFactory_StartStoppedAppContainers_Handler(srv interface{}, ctx 
 		FullMethod: ApplicationFactory_StartStoppedAppContainers_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ApplicationFactoryServer).StartStoppedAppContainers(ctx, req.(*ContainerRequestBody))
+		return srv.(ApplicationFactoryServer).StartStoppedAppContainers(ctx, req.(*DownNodeRequestBody))
 	}
 	return interceptor(ctx, in, info, handler)
 }

--- a/services/appmaker/controller.go
+++ b/services/appmaker/controller.go
@@ -26,8 +26,12 @@ type server struct {
 	pb.UnimplementedApplicationFactoryServer
 }
 
-func (s *server) StartStoppedAppContainers(ctx context.Context, body *pb.ContainerRequestBody) (*pb.ContainerResponseBody, error) {
-	CheckContainerHealth()
+func (s *server) StartStoppedAppContainers(ctx context.Context, body *pb.DownNodeRequestBody) (*pb.ContainerResponseBody, error) {
+	appsOnNode := body.GetData()
+	err := docker.BulkContainerRestart(appsOnNode)
+	if err != nil {
+		return nil, err
+	}
 
 	data, err := docker.ListContainers()
 	if err != nil {

--- a/services/appmaker/controller.go
+++ b/services/appmaker/controller.go
@@ -47,6 +47,16 @@ func (s *server) StopAppContainers(ctx context.Context, body *pb.DownNodeRequest
 	return &pb.DeletionResponse{Success: true}, nil
 }
 
+func (s *server) DeleteAppContainers(ctx context.Context, body *pb.DownNodeRequestBody) (*pb.DeletionResponse, error) {
+	appsOnNode := body.GetData()
+
+	err := docker.BulkDeleteContainers(appsOnNode)
+	if err != nil {
+		return &pb.DeletionResponse{Success: false}, err
+	}
+	return &pb.DeletionResponse{Success: true}, nil
+}
+
 // Create creates an application
 func (s *server) Create(ctx context.Context, body *pb.RequestBody) (*pb.ResponseBody, error) {
 	language := body.GetLanguage()

--- a/services/appmaker/controller.go
+++ b/services/appmaker/controller.go
@@ -28,10 +28,7 @@ type server struct {
 
 func (s *server) StartStoppedAppContainers(ctx context.Context, body *pb.DownNodeRequestBody) (*pb.ContainerResponseBody, error) {
 	appsOnNode := body.GetData()
-	err := docker.BulkContainerRestart(appsOnNode)
-	if err != nil {
-		return nil, err
-	}
+	docker.BulkContainerRestart(appsOnNode)
 
 	data, err := docker.ListContainers()
 	if err != nil {

--- a/services/master/controllers/admin.go
+++ b/services/master/controllers/admin.go
@@ -215,30 +215,25 @@ func ShiftNode(c *gin.Context) {
 		return
 	}
 
-	// targetIp, _, err := net.SplitHostPort(targetAddress)
-	// if err != nil {
-	// 	utils.SendServerErrorResponse(c, err)
-	// 	return
-	// }
-
-	appsOnNode, err := FetchAllApplicationsOnNode(hostIP)
+	appsOnHostNode, err := FetchAllApplicationsOnNode(hostIP)
 	if err != nil {
 		utils.SendServerErrorResponse(c, err)
 		return
 	}
 
-	ans, err := factory.GracefulDown(hostAddress, appsOnNode)
+	ans, err := factory.GracefulDown(hostAddress, appsOnHostNode)
 	if err != nil {
 		utils.SendServerErrorResponse(c, err)
 		return
 	}
 
-	ans, err = factory.GracefulUp(targetAddress, appsOnNode)
+	ans2, err := factory.GracefulUp(targetAddress, appsOnHostNode)
 	if err != nil {
 		utils.SendServerErrorResponse(c, err)
 		return
 	}
 
-	res["success"] = ans
+	res["success"] = ans && ans2
+
 	c.JSON(200, res)
 }

--- a/types/node.go
+++ b/types/node.go
@@ -13,3 +13,9 @@ type ShiftNodeRequest struct {
 type Response struct {
 	Message string `json:"message"`
 }
+
+type RemoveContainerList struct {
+	RemoveVolumes bool
+	RemoveLinks   bool
+	Force         bool
+}


### PR DESCRIPTION
- useful to migrate from one AppMaker worker node to another
- removes all the app containers from one node and creates them on another node
- key change : now the down node route removes containers instead of stopping them.
- route `/admin/nodes/shift`
Request Body
```json
{
    "host_ip": "100.114.106.39:4000",
    "target_ip": "100.122.134.120:4000"
}
```