### PR TITLE
Ensure Docker client is acquired whenever the Master is deployed

### DIFF
--- a/lib/docker/connection.go
+++ b/lib/docker/connection.go
@@ -11,8 +11,8 @@ import (
 
 // NewClient returns a new docker client
 func NewClient() *client.Client {
-	// No need to test docker connection if AppMaker and DbMaker are not deployed
-	if !configs.ServiceConfig.AppMaker.Deploy && !configs.ServiceConfig.DbMaker.Deploy {
+	// No need to test docker connection if Master, AppMaker and DbMaker are not deployed
+	if !configs.ServiceConfig.Master.Deploy && !configs.ServiceConfig.AppMaker.Deploy && !configs.ServiceConfig.DbMaker.Deploy {
 		return nil
 	}
 	cli, err := client.NewEnvClient()


### PR DESCRIPTION
- Previously, initialising only master service led to `nil pointer dereferencing error`, as docker client was not acquired until either `AppMaker` or `DBMaker` was to be deployed. 
- This pr adds a check to ensure that docker client is acquired when `Master` is deployed without either of `AppMaker` or `DBMaker`. 